### PR TITLE
Uri Set hard maximum for amount of comments that can be retrieved

### DIFF
--- a/src/main/java/com/google/sps/servlets/YoutubeServlet.java
+++ b/src/main/java/com/google/sps/servlets/YoutubeServlet.java
@@ -46,6 +46,7 @@ public class YoutubeServlet extends HttpServlet {
       String url = request.getParameter(URL_PARAMETER);
       String numCommentsInput = request.getParameter(NUM_COMMENTS_PARAMETER);
       // If nothing is inputted, length of list is default, otherwise it's what was inputted.
+      // If input exceeds MAX_COMMENTS, change it to MAX_COMMENTS
       long numComments =
           (numCommentsInput != null) ? Math.min(Long.valueOf(numCommentsInput), MAX_COMMENTS) : DEFAULT_COMMENTS;
 

--- a/src/main/java/com/google/sps/servlets/YoutubeServlet.java
+++ b/src/main/java/com/google/sps/servlets/YoutubeServlet.java
@@ -32,6 +32,7 @@ public class YoutubeServlet extends HttpServlet {
   private static final String URL_PARAMETER = "url";
   private static final String NUM_COMMENTS_PARAMETER = "numComments";
   private static final long DEFAULT_COMMENTS = 100L;
+  private static final long MAX_COMMENTS = 500L;
   private YouTubeCommentRetriever commentRetriever;
 
   /**
@@ -46,7 +47,7 @@ public class YoutubeServlet extends HttpServlet {
       String numCommentsInput = request.getParameter(NUM_COMMENTS_PARAMETER);
       // If nothing is inputted, length of list is default, otherwise it's what was inputted.
       long numComments =
-          (numCommentsInput != null) ? Long.valueOf(numCommentsInput) : DEFAULT_COMMENTS;
+          (numCommentsInput != null) ? Math.min(Long.valueOf(numCommentsInput), MAX_COMMENTS) : DEFAULT_COMMENTS;
 
       List<CommentThread> commentThreads =
           new YouTubeCommentRetriever().retrieveComments(url, numComments);


### PR DESCRIPTION
As per Molly/Rick's suggestion, have check on backend to prevent user from manually requesting more than our limit of 500 comments.